### PR TITLE
Filter only undyed/unplaced, dye shopping list

### DIFF
--- a/MakePlacePlugin/Configuration.cs
+++ b/MakePlacePlugin/Configuration.cs
@@ -21,6 +21,8 @@ namespace MakePlacePlugin
         public bool Basement = true;
         public bool GroundFloor = true;
         public bool UpperFloor = true;
+        public bool ShowOnlyUnplaced = false;
+        public bool ShowOnlyUndyed = false;
 
 
         public List<string> Tags = new List<string>();

--- a/MakePlacePlugin/Configuration.cs
+++ b/MakePlacePlugin/Configuration.cs
@@ -23,6 +23,7 @@ namespace MakePlacePlugin
         public bool UpperFloor = true;
         public bool ShowOnlyUnplaced = false;
         public bool ShowOnlyUndyed = false;
+        public bool LogPlacement = true;
 
 
         public List<string> Tags = new List<string>();

--- a/MakePlacePlugin/Gui/ConfigurationWindow.cs
+++ b/MakePlacePlugin/Gui/ConfigurationWindow.cs
@@ -259,6 +259,12 @@ namespace MakePlacePlugin.Gui
             if (ImGui.Checkbox("Show Only Undyed", ref Config.ShowOnlyUndyed)) Config.Save();
 
             ImGui.Dummy(new Vector2(0, 15));
+          
+            ImGui.Text("Log messages");
+
+            if (ImGui.Checkbox("Individual item placement", ref Config.LogPlacement)) Config.Save();            
+
+            ImGui.Dummy(new Vector2(0, 15));
 
             ImGui.Text("Layout Actions");
 
@@ -368,7 +374,7 @@ namespace MakePlacePlugin.Gui
 
                         if (housingItem.ItemStruct != IntPtr.Zero)
                         {
-                            SetItemPosition(housingItem);
+                            SetItemPosition(housingItem, Config.LogPlacement);
                         }
                         else
                         {
@@ -607,7 +613,7 @@ namespace MakePlacePlugin.Gui
                                 continue;
                             }
 
-                            SetItemPosition(housingItem);
+                            SetItemPosition(housingItem, Config.LogPlacement);
                             Config.HiddenScreenItemHistory.Add(i);
                             Config.Save();
                         }

--- a/MakePlacePlugin/MakePlacePlugin.cs
+++ b/MakePlacePlugin/MakePlacePlugin.cs
@@ -405,6 +405,10 @@ namespace MakePlacePlugin
                     unmatched.Add(gameObject);
                     continue;
                 }
+                else
+                {
+                    houseItem.IsPlaced = true;
+                }
                 houseItem.ItemStruct = (IntPtr)gameObject.Item;
             }
 
@@ -450,6 +454,10 @@ namespace MakePlacePlugin
                     gameObject.rotation);
                     UnusedItemList.Add(unmatchedItem);
                     continue;
+                } 
+                else
+                {
+                    houseItem.IsPlaced = true;
                 }
 
                 houseItem.ItemStruct = (IntPtr)gameObject.Item;

--- a/MakePlacePlugin/MakePlacePlugin.cs
+++ b/MakePlacePlugin/MakePlacePlugin.cs
@@ -228,7 +228,7 @@ namespace MakePlacePlugin
 
                     if (item.ItemStruct == IntPtr.Zero) continue;
 
-                    SetItemPosition(item);
+                    SetItemPosition(item, Config.LogPlacement);
 
                     if (Config.LoadInterval > 0)
                     {
@@ -251,7 +251,7 @@ namespace MakePlacePlugin
             CurrentlyPlacingItems = false;
         }
 
-        unsafe public static void SetItemPosition(HousingItem rowItem)
+        unsafe public static void SetItemPosition(HousingItem rowItem, bool logPlacement = true)
         {
 
             if (!IsDecorMode() || !IsRotateMode())
@@ -263,7 +263,9 @@ namespace MakePlacePlugin
 
             if (rowItem.ItemStruct == IntPtr.Zero) return;
 
-            Log("Placing " + rowItem.Name);
+            if (logPlacement) {
+                Log("Placing " + rowItem.Name);
+            }
 
             var MemInstance = Memory.Instance;
 

--- a/MakePlacePlugin/Objects/HousingItem.cs
+++ b/MakePlacePlugin/Objects/HousingItem.cs
@@ -19,6 +19,7 @@ namespace MakePlacePlugin.Objects
         public string Name = "";
         public IntPtr ItemStruct = IntPtr.Zero;
         public bool DyeMatch = true;
+        public bool IsPlaced = false;
         public bool IsTableOrWallMounted = false;
 
         public HousingItem(Item item, byte stain, float x, float y, float z, float rotate)


### PR DESCRIPTION
First time messing with a Dalamud plugin, unclear what the process is for versioning/publishing. If I need to do anything lmk.

- adds filter controls to show only unplaced/undyed furniture
- shows a list of dyes and how many are required for indoor/outdoor furniture

![image](https://user-images.githubusercontent.com/2505980/210895354-4564f03c-89b2-4ffc-acae-4744c70ffca3.png)